### PR TITLE
Improve gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,12 @@ subprojects {
 
         if (!project.hasProperty('skipJava8Checks')) {
           task ensureDependenciesRunOnJava8(dependsOn: [configurations.compileClasspath]) {
-            ext.readJavaMajorVersion = { classFile ->
+              inputs.files(configurations.compileClasspath)
+                      .withPropertyName('classpath').withNormalizer(ClasspathNormalizer)
+              outputs.file("$buildDir/java8Checks")
+              outputs.cacheIf { true }
+
+              ext.readJavaMajorVersion = { classFile ->
               classFile.withDataInputStream({ d ->
                 if (d.skip(7) == 7) {
                   // read the version of the class file
@@ -666,7 +671,7 @@ gradle.projectsEvaluated { gradle ->
 
 ext.osAdaptiveCommand = { commands ->
     def newCommands = []
-    
+
     if (System.properties['os.name'].toLowerCase().contains('windows')) {
       newCommands = ['cmd', '/c']
     }

--- a/build.gradle
+++ b/build.gradle
@@ -185,21 +185,21 @@ subprojects {
 
         if (!project.hasProperty('skipJava8Checks')) {
           task ensureDependenciesRunOnJava8(dependsOn: [configurations.compileClasspath]) {
-              inputs.files(configurations.compileClasspath)
-                      .withPropertyName('classpath').withNormalizer(ClasspathNormalizer)
-              outputs.file("$buildDir/java8Checks")
-              outputs.cacheIf { true }
+            inputs.files(configurations.compileClasspath)
+              .withPropertyName('classpath').withNormalizer(ClasspathNormalizer)
+            outputs.file("$buildDir/java8Checks")
+            outputs.cacheIf { true }
 
-              ext.readJavaMajorVersion = { classFile ->
-              classFile.withDataInputStream({ d ->
-                if (d.skip(7) == 7) {
-                  // read the version of the class file
-                  d.read()
-                } else {
-                  throw new GradleException("Could not read major version from $classFile")
-                }
-              })
-            }
+            ext.readJavaMajorVersion = { classFile ->
+            classFile.withDataInputStream({ d ->
+              if (d.skip(7) == 7) {
+                // read the version of the class file
+                d.read()
+              } else {
+                throw new GradleException("Could not read major version from $classFile")
+              }
+            })
+          }
 
             doLast {
               [configurations.compileClasspath].each { config ->

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ subprojects {
   apply plugin: 'com.github.hierynomus.license'
   apply plugin: 'io.spring.dependency-management'
   apply plugin: 'jacoco'
-  apply plugin: 'java'
+  apply plugin: 'java-library'
   apply plugin: 'idea'
   apply plugin: 'signing'
 
@@ -191,15 +191,15 @@ subprojects {
             outputs.cacheIf { true }
 
             ext.readJavaMajorVersion = { classFile ->
-            classFile.withDataInputStream({ d ->
-              if (d.skip(7) == 7) {
-                // read the version of the class file
-                d.read()
-              } else {
-                throw new GradleException("Could not read major version from $classFile")
-              }
-            })
-          }
+              classFile.withDataInputStream({ d ->
+                if (d.skip(7) == 7) {
+                  // read the version of the class file
+                  d.read()
+                } else {
+                  throw new GradleException("Could not read major version from $classFile")
+                }
+              })
+            }
 
             doLast {
               [configurations.compileClasspath].each { config ->
@@ -671,7 +671,7 @@ gradle.projectsEvaluated { gradle ->
 
 ext.osAdaptiveCommand = { commands ->
     def newCommands = []
-
+    
     if (System.properties['os.name'].toLowerCase().contains('windows')) {
       newCommands = ['cmd', '/c']
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/sonar-xoo-plugin/build.gradle
+++ b/plugins/sonar-xoo-plugin/build.gradle
@@ -5,17 +5,17 @@ configurations {
 configureCompileJavaToVersion 8
 
 dependencies {
-  compile 'com.google.guava:guava'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'org.apache.commons:commons-csv'
+  implementation 'com.google.guava:guava'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.commons:commons-csv'
   compileOnly project(path: ':sonar-plugin-api', configuration: 'shadow')
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile project(':sonar-plugin-api-impl')
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation project(':sonar-plugin-api-impl')
 }
 
 jar {

--- a/server/sonar-alm-client/build.gradle
+++ b/server/sonar-alm-client/build.gradle
@@ -1,23 +1,23 @@
 description = 'SonarQube :: ALM integrations :: Clients'
 
 dependencies {
-    compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-    compile project(':sonar-ws')
-    compile project(':server:sonar-webserver-api')
-    compile 'com.google.code.gson:gson'
-    compile 'com.google.guava:guava'
-    compile 'com.squareup.okhttp3:okhttp'
-    compile 'commons-codec:commons-codec'
-    compile 'com.auth0:java-jwt'
-    compile 'org.bouncycastle:bcpkix-jdk15on:1.69'
+    implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+    implementation project(':sonar-ws')
+    implementation project(':server:sonar-webserver-api')
+    implementation 'com.google.code.gson:gson'
+    implementation 'com.google.guava:guava'
+    implementation 'com.squareup.okhttp3:okhttp'
+    implementation 'commons-codec:commons-codec'
+    implementation 'com.auth0:java-jwt'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.69'
 
-    testCompile project(':sonar-plugin-api-impl')
+    testImplementation project(':sonar-plugin-api-impl')
 
-    testCompile 'junit:junit'
-    testCompile 'com.tngtech.java:junit-dataprovider'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.assertj:assertj-guava'
-    testCompile 'org.mockito:mockito-core'
-    testCompile 'com.squareup.okhttp3:mockwebserver'
+    testImplementation 'junit:junit'
+    testImplementation 'com.tngtech.java:junit-dataprovider'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.assertj:assertj-guava'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
 
 }

--- a/server/sonar-auth-bitbucket/build.gradle
+++ b/server/sonar-auth-bitbucket/build.gradle
@@ -7,19 +7,19 @@ configurations {
 dependencies {
     // please keep the list ordered
 
-    compile 'com.github.scribejava:scribejava-apis'
-    compile 'com.github.scribejava:scribejava-core'
-    compile 'com.google.code.gson:gson'
-    compile project(':server:sonar-auth-common')
+    implementation 'com.github.scribejava:scribejava-apis'
+    implementation 'com.github.scribejava:scribejava-core'
+    implementation 'com.google.code.gson:gson'
+    implementation project(':server:sonar-auth-common')
 
     compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'com.squareup.okhttp3:okhttp'
     compileOnly 'javax.servlet:javax.servlet-api'
     compileOnly project(':sonar-core')
 
-    testCompile 'com.squareup.okhttp3:mockwebserver'
-    testCompile 'com.squareup.okhttp3:okhttp'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    testImplementation 'com.squareup.okhttp3:okhttp'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/server/sonar-auth-common/build.gradle
+++ b/server/sonar-auth-common/build.gradle
@@ -7,14 +7,14 @@ configurations {
 dependencies {
     // please keep the list ordered
 
-    compile 'com.github.scribejava:scribejava-apis'
-    compile 'com.github.scribejava:scribejava-core'
+    implementation 'com.github.scribejava:scribejava-apis'
+    implementation 'com.github.scribejava:scribejava-core'
 
     compileOnly 'com.google.code.findbugs:jsr305'
 
-    testCompile 'commons-lang:commons-lang'
-    testCompile 'com.squareup.okhttp3:mockwebserver'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation 'commons-lang:commons-lang'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/server/sonar-auth-github/build.gradle
+++ b/server/sonar-auth-github/build.gradle
@@ -7,19 +7,19 @@ configurations {
 dependencies {
     // please keep the list ordered
 
-    compile 'com.github.scribejava:scribejava-apis'
-    compile 'com.github.scribejava:scribejava-core'
-    compile 'com.google.code.gson:gson'
-    compile project(':server:sonar-auth-common')
+    implementation 'com.github.scribejava:scribejava-apis'
+    implementation 'com.github.scribejava:scribejava-core'
+    implementation 'com.google.code.gson:gson'
+    implementation project(':server:sonar-auth-common')
 
     compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'com.squareup.okhttp3:okhttp'
     compileOnly 'javax.servlet:javax.servlet-api'
     compileOnly project(':sonar-core')
 
-    testCompile 'com.squareup.okhttp3:mockwebserver'
-    testCompile 'com.squareup.okhttp3:okhttp'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    testImplementation 'com.squareup.okhttp3:okhttp'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/server/sonar-auth-gitlab/build.gradle
+++ b/server/sonar-auth-gitlab/build.gradle
@@ -7,19 +7,19 @@ configurations {
 dependencies {
     // please keep the list ordered
 
-    compile 'com.github.scribejava:scribejava-apis'
-    compile 'com.github.scribejava:scribejava-core'
-    compile 'com.google.code.gson:gson'
-    compile project(':server:sonar-auth-common')
+    implementation 'com.github.scribejava:scribejava-apis'
+    implementation'com.github.scribejava:scribejava-core'
+    implementation'com.google.code.gson:gson'
+    implementation project(':server:sonar-auth-common')
 
     compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'com.squareup.okhttp3:okhttp'
     compileOnly 'javax.servlet:javax.servlet-api'
     compileOnly project(':sonar-core')
 
-    testCompile 'com.squareup.okhttp3:mockwebserver'
-    testCompile 'com.squareup.okhttp3:okhttp'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    testImplementation 'com.squareup.okhttp3:okhttp'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/server/sonar-auth-ldap/build.gradle
+++ b/server/sonar-auth-ldap/build.gradle
@@ -7,16 +7,16 @@ configurations {
 dependencies {
     // please keep the list ordered
 
-    compile 'commons-lang:commons-lang'
+    implementation 'commons-lang:commons-lang'
 
     compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'javax.servlet:javax.servlet-api'
     compileOnly project(':sonar-core')
 
-    testCompile 'com.tngtech.java:junit-dataprovider'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
-    testCompile project(":sonar-testing-ldap")
+    testImplementation 'com.tngtech.java:junit-dataprovider'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation project(":sonar-testing-ldap")
 
 }

--- a/server/sonar-auth-saml/build.gradle
+++ b/server/sonar-auth-saml/build.gradle
@@ -11,8 +11,8 @@ ext {
 dependencies {
     // please keep the list ordered
 
-    compile "com.onelogin:java-saml:${oneLoginVersion}"
-    compile "com.onelogin:java-saml-core:${oneLoginVersion}"
+    implementation "com.onelogin:java-saml:${oneLoginVersion}"
+    implementation "com.onelogin:java-saml-core:${oneLoginVersion}"
 
     compileOnly 'com.google.code.findbugs:jsr305'
     compileOnly 'com.squareup.okhttp3:okhttp'
@@ -20,9 +20,9 @@ dependencies {
     compileOnly project(':server:sonar-db-dao')
     compileOnly project(':sonar-core')
 
-    testCompile 'com.tngtech.java:junit-dataprovider'
-    testCompile 'junit:junit'
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.mockito:mockito-core'
-    testCompile testFixtures(project(':server:sonar-db-dao'))
+    testImplementation 'com.tngtech.java:junit-dataprovider'
+    testImplementation 'junit:junit'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation testFixtures(project(':server:sonar-db-dao'))
 }

--- a/server/sonar-ce-common/build.gradle
+++ b/server/sonar-ce-common/build.gradle
@@ -31,25 +31,25 @@ configurations {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:slf4j-api'
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-server-common')
-  compile project(':sonar-core')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation 'com.google.guava:guava'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:slf4j-api'
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-server-common')
+  implementation project(':sonar-core')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'commons-lang:commons-lang'
-  testCompile 'junit:junit'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.hamcrest:hamcrest-all'
-  testCompile project(':sonar-plugin-api-impl')
-  testCompile testFixtures(project(':server:sonar-server-common'))
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'commons-lang:commons-lang'
+  testImplementation 'junit:junit'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.hamcrest:hamcrest-all'
+  testImplementation project(':sonar-plugin-api-impl')
+  testImplementation testFixtures(project(':server:sonar-server-common'))
 }

--- a/server/sonar-ce-task-projectanalysis/build.gradle
+++ b/server/sonar-ce-task-projectanalysis/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 description = 'Code of the Compute Engine task processing project analysis reports'
 
 sonarqube {
@@ -17,44 +21,44 @@ sourceSets {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:slf4j-api'
-  compile 'net.sf.trove4j:core:3.1.0'
-  compile 'commons-codec:commons-codec'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.guava:guava'
-  compile 'com.google.code.findbugs:jsr305'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'com.googlecode.java-diff-utils:diffutils'
-  compile 'org.mybatis:mybatis'
-  compile 'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:slf4j-api'
+  implementation 'net.sf.trove4j:core:3.1.0'
+  implementation 'commons-codec:commons-codec'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'com.google.code.gson:gson'
+  implementation 'com.google.guava:guava'
+  implementation 'com.google.code.findbugs:jsr305'
+  implementation 'com.google.protobuf:protobuf-java'
+  implementation 'com.googlecode.java-diff-utils:diffutils'
+  implementation 'org.mybatis:mybatis'
+  implementation 'org.picocontainer:picocontainer'
 
-  compile project(':sonar-core')
-  compile project(':server:sonar-ce-common')
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-db-migration')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-server-common')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile project(':sonar-duplications')
-  compile project(':sonar-scanner-protocol')
+  api project(':sonar-core')
+  implementation project(':server:sonar-ce-common')
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-db-migration')
+  implementation project(':server:sonar-process')
+  implementation project(':server:sonar-server-common')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation project(':sonar-duplications')
+  implementation project(':sonar-scanner-protocol')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  compile project(':server:sonar-db-dao')
+  implementation project(':server:sonar-db-dao')
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.reflections:reflections'
-  testCompile project(':sonar-testing-harness')
-  testCompile testFixtures(project(':server:sonar-server-common'))
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.reflections:reflections'
+  testImplementation project(':sonar-testing-harness')
+  testImplementation testFixtures(project(':server:sonar-server-common'))
 
   testFixturesApi 'junit:junit'
   testFixturesApi 'org.assertj:assertj-core'

--- a/server/sonar-ce-task-projectanalysis/build.gradle
+++ b/server/sonar-ce-task-projectanalysis/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 description = 'Code of the Compute Engine task processing project analysis reports'
 
 sonarqube {

--- a/server/sonar-ce-task/build.gradle
+++ b/server/sonar-ce-task/build.gradle
@@ -17,29 +17,29 @@ sourceSets {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'org.picocontainer:picocontainer'
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:slf4j-api'
+  implementation 'com.google.guava:guava'
+  implementation 'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:slf4j-api'
 
-  compile project(':server:sonar-server-common')
-  compile project(':sonar-core')
+  implementation project(':server:sonar-server-common')
+  implementation project(':sonar-core')
 
   compileOnly project(path: ':sonar-plugin-api', configuration: 'shadow')
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'ch.qos.logback:logback-access'
-  testCompile 'ch.qos.logback:logback-classic'
-  testCompile 'ch.qos.logback:logback-core'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.reflections:reflections'
-  testCompile testFixtures(project(':server:sonar-db-dao'))
+  testImplementation 'ch.qos.logback:logback-access'
+  testImplementation 'ch.qos.logback:logback-classic'
+  testImplementation 'ch.qos.logback:logback-core'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.reflections:reflections'
+  testImplementation testFixtures(project(':server:sonar-db-dao'))
 
   testFixturesApi 'org.assertj:assertj-core'
   testFixturesApi project(path: ':sonar-plugin-api', configuration: 'shadow')

--- a/server/sonar-ce/build.gradle
+++ b/server/sonar-ce/build.gradle
@@ -8,35 +8,35 @@ sonarqube {
 
 dependencies {
   // please keep the list grouped by configuration and ordered by name
-  compile 'com.google.guava:guava'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'com.hazelcast:hazelcast'
-  compile 'com.hazelcast:hazelcast-kubernetes'
-  compile 'commons-io:commons-io'
-  compile 'org.apache.commons:commons-dbcp2'
-  compile 'org.nanohttpd:nanohttpd'
-  compile 'org.picocontainer:picocontainer'
-  compile project(':server:sonar-ce-common')
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-ce-task-projectanalysis')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-server-common')
-  compile project(':sonar-core')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile project(':sonar-ws')
+  implementation 'com.google.guava:guava'
+  implementation 'com.google.protobuf:protobuf-java'
+  implementation 'com.hazelcast:hazelcast'
+  implementation 'com.hazelcast:hazelcast-kubernetes'
+  implementation 'commons-io:commons-io'
+  implementation 'org.apache.commons:commons-dbcp2'
+  implementation 'org.nanohttpd:nanohttpd'
+  implementation 'org.picocontainer:picocontainer'
+  implementation project(':server:sonar-ce-common')
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-ce-task-projectanalysis')
+  implementation project(':server:sonar-process')
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-server-common')
+  implementation project(':sonar-core')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation project(':sonar-ws')
   
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.awaitility:awaitility'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.slf4j:slf4j-api'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.awaitility:awaitility'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.slf4j:slf4j-api'
   
-  testCompile testFixtures(project(':server:sonar-db-dao'))
+  testImplementation testFixtures(project(':server:sonar-db-dao'))
 
 }

--- a/server/sonar-db-core/build.gradle
+++ b/server/sonar-db-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Database Core"
@@ -7,34 +11,34 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
-  compile 'com.google.guava:guava'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'org.apache.commons:commons-dbcp2'
-  compile 'org.mybatis:mybatis'
-  compile 'org.picocontainer:picocontainer'
-  compile 'org.slf4j:slf4j-api'
-  compile project(':server:sonar-process')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
+  implementation 'ch.qos.logback:logback-classic'
+  implementation 'ch.qos.logback:logback-core'
+  implementation 'com.google.guava:guava'
+  api  'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  api 'org.apache.commons:commons-dbcp2'
+  api  'org.mybatis:mybatis'
+  implementation 'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:slf4j-api'
+  api project(':server:sonar-process')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  api project(':sonar-plugin-api-impl')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.h2database:h2'
-  testCompile 'com.microsoft.sqlserver:mssql-jdbc'
-  testCompile 'com.oracle.database.jdbc:ojdbc8'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.postgresql:postgresql'
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.h2database:h2'
+  testImplementation 'com.microsoft.sqlserver:mssql-jdbc'
+  testImplementation 'com.oracle.database.jdbc:ojdbc8'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.postgresql:postgresql'
+  testImplementation project(':sonar-testing-harness')
 
-  testRuntime 'com.h2database:h2'
-  testRuntime 'com.microsoft.sqlserver:mssql-jdbc'
-  testRuntime 'com.oracle.database.jdbc:ojdbc8'
-  testRuntime 'org.postgresql:postgresql'
+  testRuntimeOnly 'com.h2database:h2'
+  testRuntimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
+  testRuntimeOnly 'com.oracle.database.jdbc:ojdbc8'
+  testRuntimeOnly 'org.postgresql:postgresql'
 
   testFixturesApi 'commons-dbutils:commons-dbutils'
   testFixturesApi 'junit:junit'

--- a/server/sonar-db-core/build.gradle
+++ b/server/sonar-db-core/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Database Core"

--- a/server/sonar-db-dao/build.gradle
+++ b/server/sonar-db-dao/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: DAO"
@@ -7,36 +11,36 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'net.jpountz.lz4:lz4'
-  compile 'org.mybatis:mybatis'
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation 'com.google.guava:guava'
+  implementation 'com.google.protobuf:protobuf-java'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'net.jpountz.lz4:lz4'
+  implementation 'org.mybatis:mybatis'
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
-  compile project(':server:sonar-db-core')
-  compile project(':server:sonar-db-migration')
-  compile project(':sonar-core')
+  api project(':server:sonar-db-core')
+  api project(':server:sonar-db-migration')
+  implementation project(':sonar-core')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'commons-dbutils:commons-dbutils'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.sonarsource.orchestrator:sonar-orchestrator'
-  testCompile project(':sonar-testing-harness')
-  testCompile project(':sonar-plugin-api-impl')
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'commons-dbutils:commons-dbutils'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator'
+  testImplementation project(':sonar-testing-harness')
+  testImplementation project(':sonar-plugin-api-impl')
 
   testCompileOnly 'com.google.code.findbugs:jsr305'
 
-  testRuntime 'com.h2database:h2'
-  testRuntime 'com.microsoft.sqlserver:mssql-jdbc'
-  testRuntime 'com.oracle.database.jdbc:ojdbc8'
-  testRuntime 'org.postgresql:postgresql'
+  testRuntimeOnly 'com.h2database:h2'
+  testRuntimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
+  testRuntimeOnly 'com.oracle.database.jdbc:ojdbc8'
+  testRuntimeOnly 'org.postgresql:postgresql'
 
   testFixturesApi testFixtures(project(':server:sonar-db-core'))
 

--- a/server/sonar-db-dao/build.gradle
+++ b/server/sonar-db-dao/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: DAO"

--- a/server/sonar-db-migration/build.gradle
+++ b/server/sonar-db-migration/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Database Migration"
@@ -7,36 +11,36 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'commons-lang:commons-lang'
-  compile 'commons-codec:commons-codec'
-  compile 'com.fasterxml.staxmate:staxmate'
-  compile 'org.picocontainer:picocontainer'
+  implementation 'com.google.guava:guava'
+  implementation 'commons-lang:commons-lang'
+  implementation 'commons-codec:commons-codec'
+  api 'com.fasterxml.staxmate:staxmate'
+  implementation 'org.picocontainer:picocontainer'
 
-  compile project(':server:sonar-db-core')
-  compile project(':server:sonar-process')
-  compile project(':sonar-core')
+  api project(':server:sonar-db-core')
+  implementation project(':server:sonar-process')
+  api project(':sonar-core')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'commons-dbutils:commons-dbutils'
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.mindrot:jbcrypt'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.xmlunit:xmlunit-core'
-  testCompile 'org.xmlunit:xmlunit-matchers'
-  testCompile project(':sonar-scanner-protocol')
-  testCompile project(':sonar-testing-harness')
-  testCompile testFixtures(project(':server:sonar-db-core'))
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'commons-dbutils:commons-dbutils'
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.mindrot:jbcrypt'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.xmlunit:xmlunit-core'
+  testImplementation 'org.xmlunit:xmlunit-matchers'
+  testImplementation project(':sonar-scanner-protocol')
+  testImplementation project(':sonar-testing-harness')
+  testImplementation testFixtures(project(':server:sonar-db-core'))
 
-  testRuntime 'com.h2database:h2'
-  testRuntime 'com.microsoft.sqlserver:mssql-jdbc'
-  testRuntime 'com.oracle.database.jdbc:ojdbc8'
-  testRuntime 'org.postgresql:postgresql'
+  testRuntimeOnly 'com.h2database:h2'
+  testRuntimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
+  testRuntimeOnly 'com.oracle.database.jdbc:ojdbc8'
+  testRuntimeOnly 'org.postgresql:postgresql'
 }
 
 test {

--- a/server/sonar-db-migration/build.gradle
+++ b/server/sonar-db-migration/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Database Migration"

--- a/server/sonar-main/build.gradle
+++ b/server/sonar-main/build.gradle
@@ -7,34 +7,34 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
+  implementation 'ch.qos.logback:logback-classic'
+  implementation 'ch.qos.logback:logback-core'
 
   // Required by our usage of Guava for clustering : CeWorkerFactoryImpl.getClusteredWorkerUUIDs()
-  compile 'com.google.guava:guava'
-  compile 'com.hazelcast:hazelcast'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'org.apache.logging.log4j:log4j-to-slf4j'
-  compile 'org.apache.logging.log4j:log4j-api'
-  compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
-  compile 'org.elasticsearch:elasticsearch'
-  compile 'org.elasticsearch:elasticsearch-core'
-  compile 'org.slf4j:slf4j-api'
-  compile 'org.yaml:snakeyaml'
+  implementation 'com.google.guava:guava'
+  implementation 'com.hazelcast:hazelcast'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.logging.log4j:log4j-to-slf4j'
+  implementation 'org.apache.logging.log4j:log4j-api'
+  implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+  implementation 'org.elasticsearch:elasticsearch'
+  implementation 'org.elasticsearch:elasticsearch-core'
+  implementation 'org.slf4j:slf4j-api'
+  implementation 'org.yaml:snakeyaml'
   
-  compile project(':server:sonar-process')
-  compile project(':sonar-core')
+  implementation project(':server:sonar-process')
+  implementation project(':sonar-core')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.awaitility:awaitility'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'commons-logging:commons-logging:1.1.1'
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.awaitility:awaitility'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'commons-logging:commons-logging:1.1.1'
+  testImplementation project(':sonar-testing-harness')
 }

--- a/server/sonar-process/build.gradle
+++ b/server/sonar-process/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Process"
@@ -7,30 +11,30 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
-  compile 'commons-codec:commons-codec'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.guava:guava'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'com.hazelcast:hazelcast'
-  compile 'com.hazelcast:hazelcast-kubernetes'
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:slf4j-api'
-  compile project(':sonar-core')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation 'ch.qos.logback:logback-classic'
+  implementation 'ch.qos.logback:logback-core'
+  implementation 'commons-codec:commons-codec'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  api  'com.google.code.gson:gson'
+  implementation 'com.google.guava:guava'
+  implementation 'com.google.protobuf:protobuf-java'
+  api  'com.hazelcast:hazelcast'
+  api 'com.hazelcast:hazelcast-kubernetes'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:slf4j-api'
+  api project(':sonar-core')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.google.protobuf:protobuf-java'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.awaitility:awaitility'
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.google.protobuf:protobuf-java'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.awaitility:awaitility'
+  testImplementation project(':sonar-testing-harness')
 }

--- a/server/sonar-process/build.gradle
+++ b/server/sonar-process/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Process"

--- a/server/sonar-server-common/build.gradle
+++ b/server/sonar-server-common/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 description = 'Code shared between the Web Server and the Compute Engine'
 
 sonarqube {
@@ -6,42 +10,43 @@ sonarqube {
   }
 }
 
+
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'org.apache.commons:commons-email'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'com.google.guava:guava'
-  compile 'org.slf4j:slf4j-api'
-  compile 'com.squareup.okhttp3:okhttp'
-  compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
-  compile project(':server:sonar-db-dao')
-  compile project(':server:sonar-db-migration')
-  compile project(':server:sonar-process')
-  compile project(':sonar-core')
-  compile project(':sonar-markdown')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-ws')
+  api 'org.apache.commons:commons-email'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'com.google.guava:guava'
+  implementation 'org.slf4j:slf4j-api'
+  implementation 'com.squareup.okhttp3:okhttp'
+  api 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+  api project(':server:sonar-db-dao')
+  api project(':server:sonar-db-migration')
+  implementation project(':server:sonar-process')
+  api project(':sonar-core')
+  api project(':sonar-markdown')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  api project(':sonar-ws')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'org.elasticsearch.plugin:transport-netty4-client'
-  testCompile 'ch.qos.logback:logback-core'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'com.squareup.okio:okio'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile testFixtures(project(':server:sonar-db-dao'))
-  testCompile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  testCompile project(':sonar-plugin-api-impl')
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'org.elasticsearch.plugin:transport-netty4-client'
+  testImplementation 'ch.qos.logback:logback-core'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'com.squareup.okio:okio'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation testFixtures(project(':server:sonar-db-dao'))
+  testImplementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  testImplementation project(':sonar-plugin-api-impl')
+  testImplementation project(':sonar-testing-harness')
     
   testFixturesApi 'junit:junit'
   testFixturesApi testFixtures(project(':server:sonar-db-dao'))

--- a/server/sonar-server-common/build.gradle
+++ b/server/sonar-server-common/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 description = 'Code shared between the Web Server and the Compute Engine'
 
 sonarqube {

--- a/server/sonar-webserver-api/build.gradle
+++ b/server/sonar-webserver-api/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 description = 'SonarQube WebServer internal APIs, used by other Web Server modules or Core Extensions'
 
 sonarqube {
@@ -17,26 +21,26 @@ sourceSets {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'io.jsonwebtoken:jjwt-api'
-  compile 'io.jsonwebtoken:jjwt-impl'
-  compile project(':sonar-core')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-server-common')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile 'org.mindrot:jbcrypt'
+  implementation 'com.google.guava:guava'
+  implementation 'io.jsonwebtoken:jjwt-api'
+  implementation 'io.jsonwebtoken:jjwt-impl'
+  api project(':sonar-core')
+  implementation project(':server:sonar-process')
+  api project(':server:sonar-server-common')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation 'org.mindrot:jbcrypt'
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.servlet:javax.servlet-api'
 
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'javax.servlet:javax.servlet-api'
-  testCompile 'org.mockito:mockito-core'
-  testCompile testFixtures(project(':server:sonar-server-common'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.jasonar-db-coreva:junit-dataprovider'
+  testImplementation 'javax.servlet:javax.servlet-api'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation testFixtures(project(':server:sonar-server-common'))
+  testImplementation project(':sonar-testing-harness')
 
   testFixturesApi 'junit:junit'
 

--- a/server/sonar-webserver-api/build.gradle
+++ b/server/sonar-webserver-api/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 description = 'SonarQube WebServer internal APIs, used by other Web Server modules or Core Extensions'
 
 sonarqube {

--- a/server/sonar-webserver-auth/build.gradle
+++ b/server/sonar-webserver-auth/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: Authentification and Identity"
@@ -7,33 +11,33 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.guava:guava'
-  compile 'io.jsonwebtoken:jjwt-api'
-  compile 'io.jsonwebtoken:jjwt-impl'
-  compile project(':sonar-core')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-server-common')
-  compile project(':server:sonar-webserver-api')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile 'org.mindrot:jbcrypt'
+  implementation 'com.google.code.gson:gson'
+  implementation 'com.google.guava:guava'
+  implementation 'io.jsonwebtoken:jjwt-api'
+  implementation 'io.jsonwebtoken:jjwt-impl'
+  implementation project(':sonar-core')
+  implementation project(':server:sonar-process')
+  implementation project(':server:sonar-server-common')
+  api project(':server:sonar-webserver-api')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation 'org.mindrot:jbcrypt'
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.servlet:javax.servlet-api'
 
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'javax.servlet:javax.servlet-api'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.mockito:mockito-core'
-  testCompile testFixtures(project(':server:sonar-server-common'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'javax.servlet:javax.servlet-api'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation testFixtures(project(':server:sonar-server-common'))
+  testImplementation project(':sonar-testing-harness')
 
   testCompileOnly  'com.google.code.findbugs:jsr305'
 
-  runtime 'io.jsonwebtoken:jjwt-jackson'
+  runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 
   testFixturesApi 'junit:junit'
 

--- a/server/sonar-webserver-auth/build.gradle
+++ b/server/sonar-webserver-auth/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: Authentification and Identity"

--- a/server/sonar-webserver-core/build.gradle
+++ b/server/sonar-webserver-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 description = 'SonarQube WebServer-only code'
 
 sonarqube {
@@ -18,62 +22,62 @@ processResources {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'ch.qos.logback:logback-access'
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'io.jsonwebtoken:jjwt-api'
-  compile 'io.jsonwebtoken:jjwt-impl'
-  compile 'org.apache.httpcomponents:httpclient'
-  compile 'org.apache.logging.log4j:log4j-api'
-  compile 'org.apache.tomcat.embed:tomcat-embed-core'
-  compile 'org.apache.commons:commons-dbcp2'
-  compile 'org.picocontainer:picocontainer'
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:slf4j-api'
-  compile 'org.sonarsource.update-center:sonar-update-center-common'
-  compile 'org.mindrot:jbcrypt'
+  api  'ch.qos.logback:logback-access'
+  api  'ch.qos.logback:logback-classic'
+  api  'ch.qos.logback:logback-core'
+  implementation 'com.google.code.gson:gson'
+  implementation 'com.google.protobuf:protobuf-java'
+  implementation 'io.jsonwebtoken:jjwt-api'
+  implementation 'io.jsonwebtoken:jjwt-impl'
+  implementation 'org.apache.httpcomponents:httpclient'
+  implementation 'org.apache.logging.log4j:log4j-api'
+  implementation 'org.apache.tomcat.embed:tomcat-embed-core'
+  implementation 'org.apache.commons:commons-dbcp2'
+  implementation 'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:slf4j-api'
+  implementation 'org.sonarsource.update-center:sonar-update-center-common'
+  implementation 'org.mindrot:jbcrypt'
 
-  compile project(':server:sonar-ce-common')
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-ce-task-projectanalysis')
-  compile project(':server:sonar-db-migration')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-server-common')
-  compile project(':server:sonar-webserver-api')
-  compile project(':server:sonar-webserver-es')
-  compile project(':sonar-core')
-  compile project(':sonar-duplications')
-  compile project(':sonar-scanner-protocol')
-  compile project(':sonar-markdown')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile project(':sonar-ws')
+  implementation project(':server:sonar-ce-common')
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-ce-task-projectanalysis')
+  implementation project(':server:sonar-db-migration')
+  implementation project(':server:sonar-process')
+  implementation project(':server:sonar-server-common')
+  implementation project(':server:sonar-webserver-api')
+  implementation project(':server:sonar-webserver-es')
+  implementation project(':sonar-core')
+  implementation project(':sonar-duplications')
+  implementation project(':sonar-scanner-protocol')
+  implementation project(':sonar-markdown')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation project(':sonar-ws')
 
   compileOnly 'com.google.code.findbugs:jsr305'
   // not a transitive dep. At runtime lib/jdbc/h2 is used
   compileOnly 'com.h2database:h2'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.h2database:h2'
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'commons-dbutils:commons-dbutils'
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'org.eclipse.jetty:jetty-server'
-  testCompile 'org.eclipse.jetty:jetty-servlet'
-  testCompile 'org.hamcrest:hamcrest-all'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.subethamail:subethasmtp'
-  testCompile testFixtures(project(':server:sonar-server-common'))
-  testCompile testFixtures(project(':server:sonar-webserver-auth'))
-  testCompile testFixtures(project(':server:sonar-webserver-es'))
-  testCompile testFixtures(project(':server:sonar-webserver-ws'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.h2database:h2'
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'commons-dbutils:commons-dbutils'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'org.eclipse.jetty:jetty-server'
+  testImplementation 'org.eclipse.jetty:jetty-servlet'
+  testImplementation 'org.hamcrest:hamcrest-all'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.subethamail:subethasmtp'
+  testImplementation testFixtures(project(':server:sonar-server-common'))
+  testImplementation testFixtures(project(':server:sonar-webserver-auth'))
+  testImplementation testFixtures(project(':server:sonar-webserver-es'))
+  testImplementation testFixtures(project(':server:sonar-webserver-ws'))
+  testImplementation project(':sonar-testing-harness')
 
-  runtime 'io.jsonwebtoken:jjwt-jackson'
+  runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 }

--- a/server/sonar-webserver-core/build.gradle
+++ b/server/sonar-webserver-core/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 description = 'SonarQube WebServer-only code'
 
 sonarqube {

--- a/server/sonar-webserver-es/build.gradle
+++ b/server/sonar-webserver-es/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: ES"
@@ -7,22 +11,22 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile project(':server:sonar-server-common')
-  compile project(':server:sonar-webserver-auth')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation 'com.google.guava:guava'
+  api project(':server:sonar-server-common')
+  api project(':server:sonar-webserver-auth')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.servlet:javax.servlet-api'
 
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'org.mockito:mockito-core'
-  testCompile testFixtures(project(':server:sonar-webserver-auth'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation testFixtures(project(':server:sonar-webserver-auth'))
+  testImplementation project(':sonar-testing-harness')
     
   testFixturesApi testFixtures(project(':server:sonar-server-common'))
 }

--- a/server/sonar-webserver-es/build.gradle
+++ b/server/sonar-webserver-es/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: ES"

--- a/server/sonar-webserver-webapi/build.gradle
+++ b/server/sonar-webserver-webapi/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: WebAPI"
@@ -7,33 +11,33 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'com.github.everit-org.json-schema:org.everit.json.schema'
-  compile project(':server:sonar-ce-common')
-  compile project(':server:sonar-ce-task')
-  compile project(':server:sonar-db-dao')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-webserver-auth')
-  compile project(':server:sonar-webserver-es')
-  compile project(':server:sonar-webserver-ws')
-  compile project(':server:sonar-alm-client')
-  compile project(':sonar-scanner-protocol')
+  implementation 'com.google.guava:guava'
+  implementation 'com.github.everit-org.json-schema:org.everit.json.schema'
+  implementation project(':server:sonar-ce-common')
+  implementation project(':server:sonar-ce-task')
+  implementation project(':server:sonar-db-dao')
+  implementation project(':server:sonar-process')
+  api project(':server:sonar-webserver-auth')
+  api project(':server:sonar-webserver-es')
+  api project(':server:sonar-webserver-ws')
+  api project(':server:sonar-alm-client')
+  implementation project(':sonar-scanner-protocol')
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.servlet:javax.servlet-api'
 
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'org.assertj:assertj-guava'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'javax.servlet:javax.servlet-api'
-  testCompile 'org.mockito:mockito-core'
-  testCompile testFixtures(project(':server:sonar-server-common'))
-  testCompile testFixtures(project(':server:sonar-webserver-auth'))
-  testCompile testFixtures(project(':server:sonar-webserver-es'))
-  testCompile testFixtures(project(':server:sonar-webserver-ws'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'org.assertj:assertj-guava'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'javax.servlet:javax.servlet-api'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation testFixtures(project(':server:sonar-server-common'))
+  testImplementation testFixtures(project(':server:sonar-webserver-auth'))
+  testImplementation testFixtures(project(':server:sonar-webserver-es'))
+  testImplementation testFixtures(project(':server:sonar-webserver-ws'))
+  testImplementation project(':sonar-testing-harness')
 }
 

--- a/server/sonar-webserver-webapi/build.gradle
+++ b/server/sonar-webserver-webapi/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: WebServer :: WebAPI"

--- a/server/sonar-webserver-ws/build.gradle
+++ b/server/sonar-webserver-ws/build.gradle
@@ -9,21 +9,21 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile project(':sonar-core')
-  compile project(':server:sonar-webserver-api')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
-  compile project(':sonar-ws')
+  implementation 'com.google.guava:guava'
+  implementation project(':sonar-core')
+  implementation project(':server:sonar-webserver-api')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation project(':sonar-ws')
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.servlet:javax.servlet-api'
   compileOnly 'org.apache.tomcat.embed:tomcat-embed-core'
 
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'javax.servlet:javax.servlet-api'
-  testCompile 'org.apache.tomcat.embed:tomcat-embed-core'
-  testCompile 'org.mockito:mockito-core'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'javax.servlet:javax.servlet-api'
+  testImplementation 'org.apache.tomcat.embed:tomcat-embed-core'
+  testImplementation 'org.mockito:mockito-core'
 
   testFixturesApi project(':sonar-testing-harness')
 

--- a/server/sonar-webserver/build.gradle
+++ b/server/sonar-webserver/build.gradle
@@ -9,30 +9,30 @@ sonarqube {
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'com.google.guava:guava'
-  compile 'org.apache.tomcat.embed:tomcat-embed-core'
-  compile project(':sonar-core')
-  compile project(':server:sonar-auth-bitbucket')
-  compile project(':server:sonar-auth-github')
-  compile project(':server:sonar-auth-gitlab')
-  compile project(':server:sonar-auth-ldap')
-  compile project(':server:sonar-auth-saml')
-  compile project(':server:sonar-ce-task-projectanalysis')
-  compile project(':server:sonar-process')
-  compile project(':server:sonar-webserver-core')
-  compile project(':server:sonar-webserver-webapi')
+  implementation 'com.google.guava:guava'
+  implementation 'org.apache.tomcat.embed:tomcat-embed-core'
+  implementation project(':sonar-core')
+  implementation project(':server:sonar-auth-bitbucket')
+  implementation project(':server:sonar-auth-github')
+  implementation project(':server:sonar-auth-gitlab')
+  implementation project(':server:sonar-auth-ldap')
+  implementation project(':server:sonar-auth-saml')
+  implementation project(':server:sonar-ce-task-projectanalysis')
+  implementation project(':server:sonar-process')
+  implementation project(':server:sonar-webserver-core')
+  implementation project(':server:sonar-webserver-webapi')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'org.apache.logging.log4j:log4j-api'
-  testCompile 'org.apache.logging.log4j:log4j-core'
-  testCompile 'com.google.code.findbugs:jsr305'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.eclipse.jetty:jetty-server'
-  testCompile 'org.eclipse.jetty:jetty-servlet'
-  testCompile testFixtures(project(':server:sonar-server-common'))
-  testCompile testFixtures(project(':server:sonar-webserver-auth'))
-  testCompile testFixtures(project(':server:sonar-webserver-es'))
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'org.apache.logging.log4j:log4j-api'
+  testImplementation 'org.apache.logging.log4j:log4j-core'
+  testImplementation 'com.google.code.findbugs:jsr305'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.eclipse.jetty:jetty-server'
+  testImplementation 'org.eclipse.jetty:jetty-servlet'
+  testImplementation testFixtures(project(':server:sonar-server-common'))
+  testImplementation testFixtures(project(':server:sonar-webserver-auth'))
+  testImplementation testFixtures(project(':server:sonar-webserver-es'))
+  testImplementation project(':sonar-testing-harness')
 }

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -48,16 +48,16 @@ shadowJar {
 
 dependencies {
     // please keep list ordered
-    compile 'org.slf4j:slf4j-api'
+    implementation 'org.slf4j:slf4j-api'
 
-    compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
-    compile project(':server:sonar-ce')
-    compile project(':server:sonar-main')
-    compile project(':server:sonar-process')
-    compile project(':server:sonar-webserver')
-    compile project(':sonar-core')
-    compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-    compile project(':sonar-plugin-api-impl')
+    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
+    implementation project(':server:sonar-ce')
+    implementation project(':server:sonar-main')
+    implementation project(':server:sonar-process')
+    implementation project(':server:sonar-webserver')
+    implementation project(':sonar-core')
+    implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
+    implementation project(':sonar-plugin-api-impl')
 
     compileOnly 'com.google.code.findbugs:jsr305'
 
@@ -75,12 +75,17 @@ dependencies {
 apply from: 'bundled_plugins.gradle'
 
 task verifyElasticSearchDownload(type: Verify) {
+  outputs.file("$buildDir/checksum")
+  outputs.cacheIf { true }
+
   src new File(buildDir, "$elasticsearchDownloadUrlFile")
   algorithm 'SHA-512'
   checksum elasticsearchDownloadSha512
 }
 
 task downloadElasticSearch(type: Download) {
+  outputs.cacheIf { true }
+
   def artifactoryUsername = System.env.'ARTIFACTORY_PRIVATE_USERNAME' ?: (project.hasProperty('artifactoryUsername') ? project.getProperty('artifactoryUsername') : '')
   def artifactoryPassword = System.env.'ARTIFACTORY_PRIVATE_PASSWORD' ?: (project.hasProperty('artifactoryPassword') ? project.getProperty('artifactoryPassword') : '')
   if (artifactoryUsername && artifactoryPassword) {
@@ -91,7 +96,10 @@ task downloadElasticSearch(type: Download) {
     src "$elasticsearchDownloadUrlPath$elasticsearchDownloadUrlFile"
   }
   dest "$buildDir/$elasticsearchDownloadUrlFile"
-  onlyIfModified true
+
+  onlyIfModified false
+  overwrite false
+
   finalizedBy verifyElasticSearchDownload
 }
 
@@ -191,7 +199,7 @@ task zip(type: Zip, dependsOn: [configurations.compileClasspath, tasks.downloadL
   into("${archiveDir}/conf/") {
     from file('src/main/assembly/conf/wrapper.conf')
     filter(ReplaceTokens, tokens: [
-            'sqversion': version
+            'sqversion': archiveVersion.get()
     ])
   }
 

--- a/sonar-application/build.gradle
+++ b/sonar-application/build.gradle
@@ -97,6 +97,7 @@ task downloadElasticSearch(type: Download) {
   }
   dest "$buildDir/$elasticsearchDownloadUrlFile"
 
+  // Download plugin is setting upToDateWhen to false when any of onlyIfModified or overwrite are true
   onlyIfModified false
   overwrite false
 

--- a/sonar-core/build.gradle
+++ b/sonar-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Core"
@@ -9,29 +13,29 @@ configureCompileJavaToVersion 8
 dependencies {
   // please keep list ordered
 
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
-  compile 'com.google.guava:guava'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'commons-codec:commons-codec'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'org.codehaus.sonar:sonar-classloader'
-  compile 'org.picocontainer:picocontainer'
-  compile 'org.slf4j:slf4j-api'
-  compile 'org.sonarsource.update-center:sonar-update-center-common'
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
-  compile project(':sonar-plugin-api-impl')
+  api  'ch.qos.logback:logback-classic'
+  api  'ch.qos.logback:logback-core'
+  api  'com.google.guava:guava'
+  api  'com.google.protobuf:protobuf-java'
+  api 'commons-codec:commons-codec'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'org.codehaus.sonar:sonar-classloader'
+  api  'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:slf4j-api'
+  api  'org.sonarsource.update-center:sonar-update-center-common'
+  api project(path: ':sonar-plugin-api', configuration: 'shadow')
+  api project(':sonar-plugin-api-impl')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'org.simpleframework:simple'
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.simpleframework:simple'
+  testImplementation project(':sonar-testing-harness')
 
   testCompileOnly 'com.google.code.findbugs:jsr305'
 }

--- a/sonar-core/build.gradle
+++ b/sonar-core/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Core"

--- a/sonar-duplications/build.gradle
+++ b/sonar-duplications/build.gradle
@@ -7,16 +7,16 @@ sonarqube {
 dependencies {
   // please keep list ordered
 
-  compile 'org.codehaus.sonar:sonar-channel'
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation 'org.codehaus.sonar:sonar-channel'
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'ch.qos.logback:logback-classic'
-  testCompile 'commons-io:commons-io'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile 'pmd:pmd:4.3'
+  testImplementation 'ch.qos.logback:logback-classic'
+  testImplementation 'commons-io:commons-io'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation 'pmd:pmd:4.3'
 }

--- a/sonar-markdown/build.gradle
+++ b/sonar-markdown/build.gradle
@@ -9,12 +9,12 @@ configureCompileJavaToVersion 8
 dependencies {
   // please keep list ordered
 
-  compile 'commons-lang:commons-lang'
-  compile 'org.codehaus.sonar:sonar-channel'
+  implementation 'commons-lang:commons-lang'
+  implementation 'org.codehaus.sonar:sonar-channel'
 
-  testCompile 'ch.qos.logback:logback-classic'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'ch.qos.logback:logback-classic'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
 }
 
 artifactoryPublish.skip = false

--- a/sonar-plugin-api-impl/build.gradle
+++ b/sonar-plugin-api-impl/build.gradle
@@ -9,23 +9,23 @@ configureCompileJavaToVersion 8
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'commons-codec:commons-codec'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'org.apache.commons:commons-csv'
+  implementation 'commons-codec:commons-codec'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'org.apache.commons:commons-csv'
 
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'junit:junit'
 
   testCompileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.guava:guava'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.mockito:mockito-core'
+  testImplementation 'com.google.guava:guava'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.mockito:mockito-core'
 }
 
 artifactoryPublish.skip = false

--- a/sonar-plugin-api/build.gradle
+++ b/sonar-plugin-api/build.gradle
@@ -11,12 +11,12 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
   // please keep the list grouped by configuration and ordered by name
 
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'com.google.code.gson:gson'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'com.google.code.gson:gson'
 
   // shaded, but not relocated
-  compile project(':sonar-check-api')
+  implementation project(':sonar-check-api')
 
   compileOnly 'ch.qos.logback:logback-classic'
   compileOnly 'com.google.code.findbugs:jsr305'
@@ -26,11 +26,11 @@ dependencies {
   compileOnly 'org.junit.jupiter:junit-jupiter-api'
   compileOnly 'org.slf4j:slf4j-api'
 
-  testCompile 'com.google.guava:guava'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile project(':sonar-plugin-api-impl')
+  testImplementation 'com.google.guava:guava'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation project(':sonar-plugin-api-impl')
 }
 
 configurations {

--- a/sonar-scanner-engine-shaded/build.gradle
+++ b/sonar-scanner-engine-shaded/build.gradle
@@ -7,5 +7,5 @@ sonarqube {
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
-  compile project(':sonar-scanner-engine')
+  implementation project(':sonar-scanner-engine')
 }

--- a/sonar-scanner-engine/build.gradle
+++ b/sonar-scanner-engine/build.gradle
@@ -16,47 +16,47 @@ configurations {
 dependencies {
   // please keep the list ordered
 
-  compile 'ch.qos.logback:logback-classic'
-  compile 'ch.qos.logback:logback-core'
-  compile 'commons-codec:commons-codec'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile 'com.google.code.gson:gson'
-  compile 'org.apache.commons:commons-csv'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'com.squareup.okhttp3:okhttp'
-  compile 'com.fasterxml.staxmate:staxmate'
-  compile 'org.eclipse.jgit:org.eclipse.jgit'
-  compile 'org.tmatesoft.svnkit:svnkit'
-  compile 'org.picocontainer:picocontainer'
-  compile 'org.slf4j:jcl-over-slf4j'
-  compile 'org.slf4j:jul-to-slf4j'
-  compile 'org.slf4j:log4j-over-slf4j'
-  compile 'org.slf4j:slf4j-api'
-  compile 'org.sonarsource.update-center:sonar-update-center-common'
+  implementation 'ch.qos.logback:logback-classic'
+  implementation 'ch.qos.logback:logback-core'
+  implementation 'commons-codec:commons-codec'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation 'com.google.code.gson:gson'
+  implementation 'org.apache.commons:commons-csv'
+  implementation 'com.google.protobuf:protobuf-java'
+  implementation 'com.squareup.okhttp3:okhttp'
+  implementation 'com.fasterxml.staxmate:staxmate'
+  implementation 'org.eclipse.jgit:org.eclipse.jgit'
+  implementation 'org.tmatesoft.svnkit:svnkit'
+  implementation 'org.picocontainer:picocontainer'
+  implementation 'org.slf4j:jcl-over-slf4j'
+  implementation 'org.slf4j:jul-to-slf4j'
+  implementation 'org.slf4j:log4j-over-slf4j'
+  implementation 'org.slf4j:slf4j-api'
+  implementation 'org.sonarsource.update-center:sonar-update-center-common'
 
-  compile project(':sonar-core')
-  compile project(':sonar-scanner-protocol')
-  compile project(':sonar-ws')
-  compile project(':sonar-duplications')
+  implementation project(':sonar-core')
+  implementation project(':sonar-scanner-protocol')
+  implementation project(':sonar-ws')
+  implementation project(':sonar-duplications')
 
-  compile project(':sonar-plugin-api-impl')
-  compile project(path: ':sonar-plugin-api', configuration: 'shadow')
+  implementation project(':sonar-plugin-api-impl')
+  implementation project(path: ':sonar-plugin-api', configuration: 'shadow')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'com.squareup.okhttp3:okhttp'
-  testCompile 'com.squareup.okio:okio'
-  testCompile 'com.tngtech.java:junit-dataprovider'
-  testCompile 'commons-io:commons-io'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'com.fasterxml.staxmate:staxmate'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile project(':plugins:sonar-xoo-plugin')
-  testCompile project(':sonar-plugin-api').sourceSets.test.output
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'com.squareup.okhttp3:okhttp'
+  testImplementation 'com.squareup.okio:okio'
+  testImplementation 'com.tngtech.java:junit-dataprovider'
+  testImplementation 'commons-io:commons-io'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'com.fasterxml.staxmate:staxmate'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation project(':plugins:sonar-xoo-plugin')
+  testImplementation project(':sonar-plugin-api').sourceSets.test.output
 
 }
 

--- a/sonar-scanner-protocol/build.gradle
+++ b/sonar-scanner-protocol/build.gradle
@@ -9,17 +9,17 @@ configureCompileJavaToVersion 8
 
 dependencies {
   // please keep the list ordered
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'commons-io:commons-io'
-  compile 'commons-lang:commons-lang'
-  compile project(':sonar-core')
+  implementation 'com.google.code.gson:gson'
+  implementation'com.google.protobuf:protobuf-java'
+  implementation 'commons-io:commons-io'
+  implementation 'commons-lang:commons-lang'
+  implementation project(':sonar-core')
 
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'com.google.guava:guava'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'com.google.guava:guava'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
 }
 
 //create a single Jar with all dependencies
@@ -28,7 +28,7 @@ task fatJar(type: Jar) {
     attributes 'Main-Class': 'org.sonar.scanner.protocol.viewer.ScannerReportViewerApp'
   }
   archiveBaseName = project.name + '-all'
-  from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+  from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
   with jar
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/sonar-shutdowner/build.gradle
+++ b/sonar-shutdowner/build.gradle
@@ -8,8 +8,8 @@ dependencies {
   // please keep list ordered
   compileOnly 'com.google.code.findbugs:jsr305'
 
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
 }
 
 jar {

--- a/sonar-testing-harness/build.gradle
+++ b/sonar-testing-harness/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Testing Harness"
@@ -9,14 +13,14 @@ configureCompileJavaToVersion 8
 dependencies {
   // please keep list ordered
 
-  compile 'com.google.code.gson:gson'
-  compile 'com.googlecode.json-simple:json-simple'
-  compile 'com.sun.mail:javax.mail'
-  compile 'commons-io:commons-io'
-  compile 'junit:junit'
-  compile 'org.assertj:assertj-core'
-  compile 'org.hamcrest:hamcrest-core'
-  compile 'org.jsoup:jsoup'
+  implementation 'com.google.code.gson:gson'
+  api 'com.googlecode.json-simple:json-simple'
+  implementation 'com.sun.mail:javax.mail'
+  implementation 'commons-io:commons-io'
+  implementation 'junit:junit'
+  implementation 'org.assertj:assertj-core'
+  implementation 'org.hamcrest:hamcrest-core'
+  implementation 'org.jsoup:jsoup'
 
   compileOnly 'com.google.code.findbugs:jsr305'
 }

--- a/sonar-testing-harness/build.gradle
+++ b/sonar-testing-harness/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Testing Harness"

--- a/sonar-testing-ldap/build.gradle
+++ b/sonar-testing-ldap/build.gradle
@@ -5,11 +5,11 @@ sonarqube {
 }
 
 dependencies {
-    compile 'junit:junit'
-    compile 'org.apache.directory.server:apacheds-all:2.0.0-M24'
-    compile 'org.slf4j:slf4j-api'
+    implementation 'junit:junit'
+    implementation 'org.apache.directory.server:apacheds-all:2.0.0-M24'
+    implementation 'org.slf4j:slf4j-api'
 
-    testCompile 'org.assertj:assertj-core'
-    testCompile 'org.hamcrest:hamcrest-core'
-    testCompile 'org.mockito:mockito-core'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.hamcrest:hamcrest-core'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/sonar-ws-generator/build.gradle
+++ b/sonar-ws-generator/build.gradle
@@ -5,15 +5,15 @@ sonarqube {
 dependencies {
   // please keep list ordered
 
-  compile 'com.google.code.gson:gson'
-  compile 'com.google.guava:guava'
-  compile 'commons-io:commons-io'
+  implementation 'com.google.code.gson:gson'
+  implementation 'com.google.guava:guava'
+  implementation 'commons-io:commons-io'
   // transitive dependency of Velocity that must be upgraded
   // in order to fix a vulnerability
-  compile 'commons-collections:commons-collections:3.2.2'
-  compile 'org.apache.velocity:velocity:1.7'
-  compile 'org.slf4j:log4j-over-slf4j'
-  compile 'org.sonarsource.orchestrator:sonar-orchestrator'
+  implementation 'commons-collections:commons-collections:3.2.2'
+  implementation 'org.apache.velocity:velocity:1.7'
+  implementation 'org.slf4j:log4j-over-slf4j'
+  implementation 'org.sonarsource.orchestrator:sonar-orchestrator'
 
   compileOnly 'com.google.code.findbugs:jsr305'
 }

--- a/sonar-ws/build.gradle
+++ b/sonar-ws/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Web Service"
@@ -14,23 +18,23 @@ configurations {
 dependencies {
   // please keep list ordered
 
-  compile 'com.google.protobuf:protobuf-java'
-  compile 'com.squareup.okhttp3:okhttp'
-  compile 'com.google.code.gson:gson'
+  implementation 'com.google.protobuf:protobuf-java'
+  api 'com.squareup.okhttp3:okhttp'
+  implementation 'com.google.code.gson:gson'
 
   compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'javax.annotation:javax.annotation-api'
   compileOnly project(path: ':sonar-plugin-api', configuration: 'shadow')
 
-  testCompile 'com.squareup.okhttp3:mockwebserver'
-  testCompile 'com.squareup.okio:okio'
-  testCompile 'commons-io:commons-io'
-  testCompile 'commons-lang:commons-lang'
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.hamcrest:hamcrest-core'
-  testCompile 'org.mockito:mockito-core'
-  testCompile project(':sonar-testing-harness')
+  testImplementation 'com.squareup.okhttp3:mockwebserver'
+  testImplementation 'com.squareup.okio:okio'
+  testImplementation 'commons-io:commons-io'
+  testImplementation 'commons-lang:commons-lang'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.hamcrest:hamcrest-core'
+  testImplementation 'org.mockito:mockito-core'
+  testImplementation project(':sonar-testing-harness')
 }
 
 artifactoryPublish.skip = false

--- a/sonar-ws/build.gradle
+++ b/sonar-ws/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    id 'java-library'
-}
-
 sonarqube {
   properties {
     property 'sonar.projectName', "${projectTitle} :: Web Service"


### PR DESCRIPTION
- Made tasks cacheable
Made some of the tasks cacheable to improve build performance

- Upgrade gradle to 6.9.1
This project was using an older version of 6.x.x, I upgraded it to 6.9.1 with the mention that it can be upgraded to the latest 7.x version by upgrading the license plugin as well.

- Remove deprecated build code
I removed deprecated build code so that the project can be upgraded to the latest 7.x gradle version in the future


- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
